### PR TITLE
fix: avoid compilation issues with `LoaderFrom`

### DIFF
--- a/src/Dataloader.factory.ts
+++ b/src/Dataloader.factory.ts
@@ -86,8 +86,10 @@ abstract class DataloaderFactory<ID, Value, NotFoundValue = null, CacheID = ID> 
   abstract id(entity: Value): ID
 }
 
+// I would happily remove the `any` type but I could not figure out how to do it without it. 🥺
 /** Type extractor to get to the underlying Dataloader type that the factory creates */
-type LoaderFrom<TFactory extends DataloaderFactory<unknown, unknown>> = ReturnType<TFactory['create']>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LoaderFrom<TFactory extends DataloaderFactory<any, any>> = ReturnType<TFactory['create']>
 
 /**
  * Aggregated represents a result that aggregates values based on a specific ID property of values. Very useful to work

--- a/test/DataloaderFactory.test.ts
+++ b/test/DataloaderFactory.test.ts
@@ -1,12 +1,15 @@
 import { describe } from 'vitest'
 import { type ExecutionContext } from '@nestjs/common'
 import DataLoader from 'dataloader'
-import { DataloaderFactory, type Aggregated } from '@strv/nestjs-dataloader'
+import { type LoaderFrom, DataloaderFactory, type Aggregated } from '@strv/nestjs-dataloader'
 
 class TestFactory extends DataloaderFactory<unknown, unknown> {
   load = async () => await Promise.resolve([])
   id = (key: unknown) => key
 }
+// This is a test to make sure the `LoaderFrom` extractor type works correctly and the code can be compiled.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type TestLoader = LoaderFrom<TestFactory>
 
 describe('DataloaderFactory', it => {
   it('is a class', t => {


### PR DESCRIPTION
Fixes Type error when using `LoaderFrom` due to use of `DataloaderFactory<unknown, unknown>` (typescript 5.8.3) #15