### PR TITLE
chore: witch to explicit `type` exports and enable `verbatimModuleSyntax`.

### DIFF
--- a/src/Dataloader.factory.ts
+++ b/src/Dataloader.factory.ts
@@ -103,6 +103,6 @@ interface Aggregated<ID, Value> {
 
 export {
   DataloaderFactory,
-  LoaderFrom,
-  Aggregated,
+  type LoaderFrom,
+  type Aggregated,
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export { LifetimeKeyFn, DataloaderOptions, DataloaderModuleOptions } from './types.js'
+export type { LifetimeKeyFn, DataloaderOptions, DataloaderModuleOptions } from './types.js'
 export { DataloaderException } from './DataloaderException.js'
 export { Loader, createLoaderDecorator } from './Loader.decorator.js'
-export { DataloaderFactory, LoaderFrom, Aggregated } from './Dataloader.factory.js'
+export { DataloaderFactory, type LoaderFrom, type Aggregated } from './Dataloader.factory.js'
 export { DataloaderModule } from './Dataloader.module.js'

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ interface DataloaderOptions {
 /** Dataloader module options for async configuration */
 type DataloaderModuleOptions = Omit<FactoryProvider<DataloaderOptions>, 'provide'> & Pick<DynamicModule, 'imports'>
 
-export {
+export type {
   Factory,
   LifetimeKeyFn,
   DataloaderOptions,

--- a/test/Loader.test.ts
+++ b/test/Loader.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest'
 import Dataloader from 'dataloader'
 import { describe } from 'vitest'
 import { Controller, Get, Injectable } from '@nestjs/common'
-import { NestExpressApplication } from '@nestjs/platform-express'
+import { type NestExpressApplication } from '@nestjs/platform-express'
 import { Test } from '@nestjs/testing'
 import { DataloaderModule, DataloaderFactory, type LoaderFrom, Loader } from '@strv/nestjs-dataloader'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,5 +28,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedIndexedAccess": true,
     "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
- Updated code to use explicit `type` exports, following TypeScript best practices and ensuring a type is never used as a value.
- Enabled `verbatimModuleSyntax` for better adherence to TypeScript module syntax standards. It will also cause a build error if a type is used as value (class, constant, ...).

## Background

I encounter errors when enabling verbatimModuleSyntax on my NestJS app, with errors reported from `nestjs-dataloader`: TS will complain that types are exported as values:

```
../../node_modules/@strv/nestjs-dataloader/src/Dataloader.factory.ts:106:3 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

106   LoaderFrom,
      ~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/Dataloader.factory.ts:107:3 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

107   Aggregated,
      ~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/index.ts:1:10 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

1 export { LifetimeKeyFn, DataloaderOptions, DataloaderModuleOptions } from './types.js'
           ~~~~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/index.ts:1:25 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

1 export { LifetimeKeyFn, DataloaderOptions, DataloaderModuleOptions } from './types.js'
                          ~~~~~~~~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/index.ts:1:44 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

1 export { LifetimeKeyFn, DataloaderOptions, DataloaderModuleOptions } from './types.js'
                                             ~~~~~~~~~~~~~~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/index.ts:4:29 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

4 export { DataloaderFactory, LoaderFrom, Aggregated } from './Dataloader.factory.js'
                              ~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/index.ts:4:41 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

4 export { DataloaderFactory, LoaderFrom, Aggregated } from './Dataloader.factory.js'
                                          ~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/types.ts:34:3 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

34   Factory,
     ~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/types.ts:35:3 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

35   LifetimeKeyFn,
     ~~~~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/types.ts:36:3 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

36   DataloaderOptions,
     ~~~~~~~~~~~~~~~~~
../../node_modules/@strv/nestjs-dataloader/src/types.ts:37:3 - error TS1205: Re-exporting a type when 'verbatimModuleSyntax' is enabled requires using 'export type'.

37   DataloaderModuleOptions,
```