### PR TITLE
fix: share one DataLoader per request across concurrent @Loader() resolutions

### DIFF
--- a/src/Loader.decorator.ts
+++ b/src/Loader.decorator.ts
@@ -17,23 +17,30 @@ function createLoaderDecorator(lifetime: LifetimeKeyFn) {
       throw new DataloaderException('DataloaderModule not available in this Nest.js application')
     }
 
+    // GraphQL resolves sibling list fields concurrently, so a single request can invoke this decorator for the same
+    // Factory many times before any of them finishes constructing the loader. Memoise the creation *promise*
+    // synchronously - before the first `await` - so every concurrent resolution awaits and shares one loader instance.
+    // Storing the resolved loader after an `await` instead would let each invocation pass the `has()` check and mint
+    // its own loader, defeating per-request batching and caching.
     if (!item.dataloaders.has(Factory)) {
-      const { scope } = item.moduleRef.introspect(Factory)
+      item.dataloaders.set(Factory, (async () => {
+        const { scope } = item.moduleRef.introspect(Factory)
 
-      const factory = await (async () => {
-        switch (scope) {
-          case Scope.DEFAULT: return item.moduleRef.get(Factory, { strict: false })
-          case Scope.TRANSIENT:
-          case Scope.REQUEST:
-          default: return await item.moduleRef
-            .resolve(Factory, ContextIdFactory.getByRequest(lifetime(context)), { strict: false })
-        }
-      })()
+        const factory = await (async () => {
+          switch (scope) {
+            case Scope.DEFAULT: return item.moduleRef.get(Factory, { strict: false })
+            case Scope.TRANSIENT:
+            case Scope.REQUEST:
+            default: return await item.moduleRef
+              .resolve(Factory, ContextIdFactory.getByRequest(lifetime(context)), { strict: false })
+          }
+        })()
 
-      item.dataloaders.set(Factory, factory.create(context))
+        return factory.create(context)
+      })())
     }
 
-    return item.dataloaders.get(Factory)
+    return await item.dataloaders.get(Factory)
   })
 }
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -12,8 +12,11 @@ const OPTIONS_TOKEN = Symbol('DataloaderModuleOptions')
 interface StoreItem {
   /** ModuleRef is used by the `@Loader()` decorator to pull the Factory instance from Nest's DI container */
   moduleRef: ModuleRef
-  /** Dataloaders already constructed by a given Factory for this request. */
-  dataloaders: Map<Factory, DataLoader<unknown, unknown>>
+  /**
+   * Dataloaders being constructed by a given Factory for this request. The value is the loader's *creation
+   * promise* so that concurrent `@Loader()` resolutions memoise and share a single instance (see Loader.decorator).
+   */
+  dataloaders: Map<Factory, Promise<DataLoader<unknown, unknown>>>
 }
 
 /**

--- a/test/Loader.test.ts
+++ b/test/Loader.test.ts
@@ -131,4 +131,48 @@ describe('@Loader()', it => {
     t.expect(response.status).toBe(200)
     t.expect(response.body).toEqual({ text: 'Hello world' })
   })
+  it('reuses a single dataloader across concurrent resolutions within one request', async t => {
+    let created = 0
+    const seen: Array<LoaderFrom<SampleLoaderFactory>> = []
+
+    @Injectable()
+    class SampleLoaderFactory extends DataloaderFactory<string, string> {
+      load = async (keys: string[]) => await Promise.resolve(keys)
+      id = (key: string) => key
+      override create(context: Parameters<DataloaderFactory<string, string>['create']>[0]) {
+        created += 1
+        return super.create(context)
+      }
+    }
+
+    @Controller()
+    class TestController {
+      @Get('/')
+      handle(
+        @Loader(SampleLoaderFactory) first: LoaderFrom<SampleLoaderFactory>,
+        @Loader(SampleLoaderFactory) second: LoaderFrom<SampleLoaderFactory>,
+      ) {
+        seen.push(first, second)
+      }
+    }
+
+    const module = await Test.createTestingModule({
+      imports: [
+        DataloaderModule.forRoot(),
+      ],
+      providers: [
+        SampleLoaderFactory,
+      ],
+      controllers: [TestController],
+    }).compile()
+    const app = await module.createNestApplication<NestExpressApplication>().init()
+    t.onTestFinished(async () => await app.close())
+
+    await request(app.getHttpServer()).get('/')
+
+    // The @Loader() params resolve concurrently; both must receive the same
+    // per-request instance, constructed exactly once.
+    t.expect(created).toBe(1)
+    t.expect(seen[0]).toBe(seen[1])
+  })
 })


### PR DESCRIPTION
## Problem

`@Loader()` mints a **separate `DataLoader` per concurrent resolution** within a single request, defeating per-request batching and caching.

The param decorator memoizes loaders in a per-request `Map`, but the check and the set straddle an `await`:

```ts
if (!item.dataloaders.has(Factory)) {
  const { scope } = item.moduleRef.introspect(Factory)
  const factory = await (async () => { /* moduleRef.get / .resolve */ })() // ← yields
  item.dataloaders.set(Factory, factory.create(context))
}
return item.dataloaders.get(Factory)
```

GraphQL resolves sibling list fields concurrently, so the runtime invokes the decorator for the same `Factory` many times before any of them reaches the `set(...)`. Every invocation sees `has() === false`, awaits, and constructs its own loader. The result: each list item triggers its own batch-function call → one query per item instead of one batched query (the classic N+1 that `DataLoader` is meant to prevent).

## Fix

Store the loader's **creation promise** in the map *synchronously*, before the first `await`, so concurrent resolutions await and share one instance:

```ts
if (!item.dataloaders.has(Factory)) {
  item.dataloaders.set(Factory, (async () => {
    const { scope } = item.moduleRef.introspect(Factory)
    const factory = await (async () => { /* moduleRef.get / .resolve */ })()
    return factory.create(context)
  })())
}
return await item.dataloaders.get(Factory)
```

The map value type changes from `DataLoader` to `Promise<DataLoader>` (`internal.ts`); the decorator awaits it on return. The decorator is the only reader of that map, and it was already `async`, so consumers are unaffected.

## Test

Added a test that resolves the same factory for two `@Loader()` params in one request and asserts the loader is constructed **once** and both params receive the **same instance**. It fails on `master` (loader constructed twice) and passes with the fix.

`make test` (12 passing) and `make lint` are green.